### PR TITLE
add Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  jekyll: .rubocop.yml

--- a/jekyll-cloudinary.gemspec
+++ b/jekyll-cloudinary.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rubocop", "~> 0.42"
 end


### PR DESCRIPTION
This PR just add  latest Rubocop (Ruby Linter) in order to respect the same rules as Jekyll defined in the Github Ruby Styleguide.