### PR TITLE
A few upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/lib/jekyll/cloudinary.rb
+++ b/lib/jekyll/cloudinary.rb
@@ -49,8 +49,7 @@ module Jekyll
           "page"               => false,
           "density"            => false,
           "flags"              => false,
-          "transformation"     => false,
-          "url2png"            => false
+          "transformation"     => false
         }
 
         # TODO: Add validation for this parameters
@@ -120,10 +119,11 @@ module Jekyll
         
         # Dynamic image type
         type = "fetch"
-        if /^url2png\:/.match(image_src)
-          type = "url2png"
-          image_src.gsub! "url2png:", ""
-        end
+        # TODO: URL2PNG requires signed URLs… need to investigate more
+        # if /^url2png\:/.match(image_src)
+        #   type = "url2png"
+        #   image_src.gsub! "url2png:", ""
+        # end
         
         # Build source image URL
         is_image_remote = /^https?/.match(image_src)
@@ -220,6 +220,8 @@ module Jekyll
         # Get source image natural width
         image = false
         fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/#{type}/#{transformations_string}w_#{preset["fallback_max_width"]}/#{image_url}"
+        natural_width = 100_000
+        width_height = ""
         # Standard fetch
         if type == "fetch"
           # Trap format support issues from ImageMagick
@@ -239,8 +241,6 @@ module Jekyll
             natural_height = image.rows
             width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
           else
-            natural_width = 100_000
-            width_height = ""
             fallback_url = image_url
             Jekyll.logger.warn(
               "[Cloudinary]",

--- a/lib/jekyll/cloudinary.rb
+++ b/lib/jekyll/cloudinary.rb
@@ -3,6 +3,7 @@ module Jekyll
 
     class CloudinaryTag < Liquid::Tag
       require "RMagick"
+      require "open-uri"
 
       def initialize(tag_name, markup, tokens)
         @markup = markup
@@ -19,7 +20,66 @@ module Jekyll
           "sizes"              => "100vw",
           "figure"             => "auto",
           "attributes"         => {},
-          "verbose"            => false
+          "verbose"            => false,
+          "width_height"       => true,
+          # Cloudinary transformations
+          "height"             => false,
+          "crop"               => "limit",
+          "aspect_ratio"       => false,
+          "gravity"            => false,
+          "zoom"               => false,
+          "x"                  => false,
+          "y"                  => false,
+          "format"             => false,
+          "fetch_format"       => "auto",
+          "quality"            => "auto",
+          "radius"             => false,
+          "angle"              => false,
+          "effect"             => false,
+          "opacity"            => false,
+          "border"             => false,
+          "background"         => false,
+          "overlay"            => false,
+          "underlay"           => false,
+          "default_image"      => false,
+          "delay"              => false,
+          "color"              => false,
+          "color_space"        => false,
+          "dpr"                => false,
+          "page"               => false,
+          "density"            => false,
+          "flags"              => false,
+          "transformation"     => false
+        }
+
+        # TODO: Add validation for this parameters
+        transformation_options = {
+          "height"             => "h",
+          "crop"               => "c",
+          "aspect_ratio"       => "ar",
+          "gravity"            => "g",
+          "zoom"               => "z",
+          "x"                  => "x",
+          "y"                  => "y",
+          "fetch_format"       => "f",
+          "quality"            => "q",
+          "radius"             => "r",
+          "angle"              => "a",
+          "effect"             => "e",
+          "opacity"            => "o",
+          "border"             => "bo",
+          "background"         => "b",
+          "overlay"            => "l",
+          "underlay"           => "u",
+          "default_image"      => "d",
+          "delay"              => "dl",
+          "color"              => "co",
+          "color_space"        => "cs",
+          "dpr"                => "dpr",
+          "page"               => "pg",
+          "density"            => "dn",
+          "flags"              => "fl",
+          "transformation"     => "t"
         }
 
         # Settings
@@ -56,24 +116,32 @@ module Jekyll
         end
 
         image_src = markup[:image_src]
-
+        
         # Build source image URL
-        is_image_path_absolute = %r!^/.*$!.match(image_src)
-        if is_image_path_absolute
-          image_path = File.join(site.config["destination"], image_src)
-          image_url = File.join(url, baseurl, image_src)
+        is_image_remote = /^https?/.match(image_src)
+        # It’s remote
+        if is_image_remote
+          image_path = image_src
+          image_url = image_src
+        # It’s local
         else
-          image_path = File.join(
-            site.config["destination"],
-            File.dirname(context["page"].url),
-            image_src
-          )
-          image_url = File.join(
-            url,
-            baseurl,
-            File.dirname(context["page"].url),
-            image_src
-          )
+          is_image_path_absolute = %r!^/.*$!.match(image_src)
+          if is_image_path_absolute
+            image_path = File.join(site.config["destination"], image_src)
+            image_url = File.join(url, baseurl, image_src)
+          else
+            image_path = File.join(
+              site.config["destination"],
+              File.dirname(context["page"]["url"]),
+              image_src
+            )
+            image_url = File.join(
+              url,
+              baseurl,
+              File.dirname(context["page"]["url"]),
+              image_src
+            )
+          end
         end
 
         if markup[:preset]
@@ -129,13 +197,33 @@ module Jekyll
 
         attr_string = html_attr.map { |a, v| "#{a}=\"#{v}\"" }.join(" ")
 
+        # Figure out the Cloudinary transformations
+        transformations = []
+        transformations_string = ""
+        transformation_options.each do | key, shortcode |
+          if preset[key]
+            transformations << "#{shortcode}_#{preset[key]}"
+          end
+        end
+        if transformations.length > 0
+          transformations_string = transformations.compact.reject(&:empty?).join(',') + ","
+        end
+
         # Get source image natural width
-        if File.exist?(image_path)
+        if is_image_remote
+          image = Magick::ImageList.new
+          urlimage = open(image_url) # Image Remote URL 
+          image.from_blob(urlimage.read)
+          natural_width = image.columns
+          natural_height = image.rows
+          width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
+          fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/#{transformations_string}w_#{preset["fallback_max_width"]}/#{image_url}"
+        elsif File.exist?(image_path)
           image = Magick::Image::read(image_path).first
           natural_width = image.columns
           natural_height = image.rows
           width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
-          fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/c_limit,w_#{preset["fallback_max_width"]},q_auto,f_auto/#{image_url}"
+          fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/#{transformations_string}w_#{preset["fallback_max_width"]}/#{image_url}"
         else
           natural_width = 100_000
           width_height = ""
@@ -145,6 +233,10 @@ module Jekyll
             Try to run Jekyll build a second time."
           )
           fallback_url = image_url
+        end
+
+        if preset["width_height"] == false
+          width_height = ""
         end
 
         srcset = []
@@ -159,27 +251,27 @@ module Jekyll
             Jekyll.logger.warn(
               "[Cloudinary]",
               "Width of source image '#{File.basename(image_src)}' (#{natural_width}px) \
-              in #{context["page"].path} not enough for ANY srcset version"
+              in #{context["page"]["path"]} not enough for ANY srcset version"
             )
           end
-          srcset << "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/c_limit,w_#{natural_width},q_auto,f_auto/#{image_url} #{natural_width}w"
+          srcset << "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/#{transformations_string}w_#{natural_width}/#{image_url} #{natural_width}w"
         else
           missed_sizes = []
           (1..steps).each do |factor|
             width = min_width + (factor - 1) * step_width
             if width <= natural_width
-              srcset << "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/c_limit,w_#{width},q_auto,f_auto/#{image_url} #{width}w"
+              srcset << "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/#{transformations_string}w_#{width}/#{image_url} #{width}w"
             else
               missed_sizes.push(width)
             end
           end
           unless missed_sizes.empty?
-            srcset << "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/c_limit,w_#{natural_width},q_auto,f_auto/#{image_url} #{natural_width}w"
+            srcset << "https://res.cloudinary.com/#{settings["cloud_name"]}/image/fetch/#{transformations_string}w_#{natural_width}/#{image_url} #{natural_width}w"
             if settings["verbose"]
               Jekyll.logger.warn(
                 "[Cloudinary]",
                 "Width of source image '#{File.basename(image_src)}' (#{natural_width}px) \
-                in #{context["page"].path} not enough for #{missed_sizes.join("px, ")}px \
+                in #{context["page"]["path"]} not enough for #{missed_sizes.join("px, ")}px \
                 version#{missed_sizes.length > 1 ? "s" : ""}"
               )
             end

--- a/lib/jekyll/cloudinary/version.rb
+++ b/lib/jekyll/cloudinary/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Cloudinary
-    VERSION = "1.6.0".freeze
+    VERSION = "1.6.1".freeze
   end
 end

--- a/lib/jekyll/cloudinary/version.rb
+++ b/lib/jekyll/cloudinary/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Cloudinary
-    VERSION = "1.6.1".freeze
+    VERSION = "1.6.0".freeze
   end
 end


### PR DESCRIPTION
I know these should probably have been done separately (and I can re-submit that way if necessary), but this rolls up a bunch of tweaks and additions to the plugin:

1. I added the ability to customize the Cloudinary transformations. No validation on the values you supply right now, but it also defaults to the original plugin setup if you don’t use any of them (for backwards compat).
2. Added support for remote images (ones not on your server) - I was getting RMagick complaints when using them, despite this plugin using fetch
3. I ran into this error when running the plugin: `jekyll-cloudinary/lib/jekyll/cloudinary.rb:127:in `render': undefined method `url' for #<Hash:0x007f848b0e2380> (NoMethodError)` - The references to `context["page"].url`, etc. were causing issues, so I converted them to their hash equivalents (e.g., `context["page"]["url"]`).

In my testing so far, it seems to be working a treat. I bumped the patch on the version number, but this may warrant a minor version change. Up to you.

I also added ot the `.gitignore` so built gems are ignored.
