### PR TITLE
Small feature: add optional 'origin_url' var to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ or
 [Cloudinary] Natural width of source image 'img.jpg' (720px) in _posts/2016-06-09-post.md not enough for creating 1600px version
 ```
 
+#### `url`
+
+When `url` is set, jekyll-cloudinary will use this url, rather than `site.url` to build image links. This has two key use cases:
+
+1. When your images are stored on different server than where your site is hosted, use the `url` setting to point correctly to them.
+
+2. In development mode, `site.url` is overridden by Jekyll to `localhost:4000`. This has the unfortunate consequence of breaking all
+Cloudinary tagged images on your site, because Cloudinary cannot fetch remotely from your localhost. Jekyll recommends that you run the site in `production` mode as a work around, but this has the consequence of pointing all internal links to your site's domain.
+
+Using the `url` setting you can mitigate this by pointing the loudinary images to the url where they exist, while allowing your development site to still function correctly.
+
 ### Optional (but highly recommended) presets
 
 You can now define the presets you need for your posts' images, starting with the default one:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can now define some global settings
 cloudinary:
   …
   verbose: true
+  origin_url: https://another-domain.com
 ```
 
 #### `verbose` (default: `false`)
@@ -98,14 +99,9 @@ or
 
 #### `origin_url`
 
-When `origin_url` is set, jekyll-cloudinary will use this url, rather than `site.url` to build image links. This has two key use cases:
+When `origin_url` is set, jekyll-cloudinary will use this URL rather than `site.url` as origin of the source images.
 
-1. When your images are stored on different server than where your site is hosted, use the `origin_url` setting to point correctly to them.
-
-2. In development mode, `site.url` is overridden by Jekyll to `localhost:4000`. This has the unfortunate consequence of breaking all
-Cloudinary tagged images on your site, because Cloudinary cannot fetch remotely from your localhost. Jekyll recommends that you run the site in `production` mode as a work around, but this has the consequence of pointing all internal links to your site's domain.
-
-Using the `origin_url` setting you can mitigate this by pointing the loudinary images to the URL where they exist, while allowing your development site to still function correctly.
+This allows you to store your source image on a different domain than your website.
 
 ### Optional (but highly recommended) presets
 

--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ or
 [Cloudinary] Natural width of source image 'img.jpg' (720px) in _posts/2016-06-09-post.md not enough for creating 1600px version
 ```
 
-#### `url`
+#### `origin_url`
 
-When `url` is set, jekyll-cloudinary will use this url, rather than `site.url` to build image links. This has two key use cases:
+When `origin_url` is set, jekyll-cloudinary will use this url, rather than `site.url` to build image links. This has two key use cases:
 
-1. When your images are stored on different server than where your site is hosted, use the `url` setting to point correctly to them.
+1. When your images are stored on different server than where your site is hosted, use the `origin_url` setting to point correctly to them.
 
 2. In development mode, `site.url` is overridden by Jekyll to `localhost:4000`. This has the unfortunate consequence of breaking all
 Cloudinary tagged images on your site, because Cloudinary cannot fetch remotely from your localhost. Jekyll recommends that you run the site in `production` mode as a work around, but this has the consequence of pointing all internal links to your site's domain.
 
-Using the `url` setting you can mitigate this by pointing the loudinary images to the url where they exist, while allowing your development site to still function correctly.
+Using the `origin_url` setting you can mitigate this by pointing the loudinary images to the URL where they exist, while allowing your development site to still function correctly.
 
 ### Optional (but highly recommended) presets
 

--- a/jekyll-cloudinary.gemspec
+++ b/jekyll-cloudinary.gemspec
@@ -3,12 +3,12 @@ require "jekyll/cloudinary/version"
 
 Gem::Specification.new do |spec|
   spec.version = Jekyll::Cloudinary::VERSION
-  spec.homepage = "https://nhoizey.github.io/jekyll-cloudinary/"
-  spec.authors = ["Nicolas Hoizey"]
-  spec.email = ["nicolas@hoizey.com"]
+  spec.homepage = "https://github.com/suprafly/jekyll-cloudinary"
+  spec.authors = ["Chris Lyman (a fork of Nicolas Hoizey's work)"]
+  spec.email = [""]
   spec.files = %W(Rakefile Gemfile README.md LICENSE) + Dir["lib/**/*"]
   spec.summary = "Liquid tag for Jekyll with Cloudinary"
-  spec.name = "jekyll-cloudinary"
+  spec.name = "jekyll-cloudinary-fork"
   spec.license = "MIT"
   spec.has_rdoc = false
   spec.require_paths = ["lib"]

--- a/jekyll-cloudinary.gemspec
+++ b/jekyll-cloudinary.gemspec
@@ -3,12 +3,12 @@ require "jekyll/cloudinary/version"
 
 Gem::Specification.new do |spec|
   spec.version = Jekyll::Cloudinary::VERSION
-  spec.homepage = "https://github.com/suprafly/jekyll-cloudinary"
-  spec.authors = ["Chris Lyman (a fork of Nicolas Hoizey's work)"]
-  spec.email = [""]
+  spec.homepage = "https://nhoizey.github.io/jekyll-cloudinary/"
+  spec.authors = ["Nicolas Hoizey"]
+  spec.email = ["nicolas@hoizey.com"]
   spec.files = %W(Rakefile Gemfile README.md LICENSE) + Dir["lib/**/*"]
   spec.summary = "Liquid tag for Jekyll with Cloudinary"
-  spec.name = "jekyll-cloudinary-fork"
+  spec.name = "jekyll-cloudinary"
   spec.license = "MIT"
   spec.has_rdoc = false
   spec.require_paths = ["lib"]

--- a/lib/jekyll/cloudinary.rb
+++ b/lib/jekyll/cloudinary.rb
@@ -83,9 +83,9 @@ module Jekyll
 
         # Settings
         site = context.registers[:site]
-        url = site.config["url"]
         baseurl = site.config["baseurl"] || ""
         settings = site.config["cloudinary"]
+        url = settings["url"] || site.config["url"]
 
         # Get Markdown converter
         markdown_converter = site.find_converter_instance(::Jekyll::Converters::Markdown)

--- a/lib/jekyll/cloudinary.rb
+++ b/lib/jekyll/cloudinary.rb
@@ -196,7 +196,7 @@ module Jekyll
           image_dest_path = image_src
           image_dest_url = image_src
           natural_width, natural_height = FastImage.size(image_dest_url)
-          width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
+          # width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
           fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/#{type}/#{transformations_string}w_#{preset["fallback_max_width"]}/#{image_dest_url}"
         else
           # It’s a local image
@@ -235,7 +235,7 @@ module Jekyll
           end
           if File.exist?(image_src_path)
             natural_width, natural_height = FastImage.size(image_src_path)
-            width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
+            # width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
             fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/#{type}/#{transformations_string}w_#{preset["fallback_max_width"]}/#{image_dest_url}"
           else
             natural_width = 100_000

--- a/lib/jekyll/cloudinary.rb
+++ b/lib/jekyll/cloudinary.rb
@@ -85,7 +85,7 @@ module Jekyll
         site = context.registers[:site]
         baseurl = site.config["baseurl"] || ""
         settings = site.config["cloudinary"]
-        url = settings["url"] || site.config["url"]
+        url = settings["origin_url"] || site.config["url"]
 
         # Get Markdown converter
         markdown_converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
@@ -196,7 +196,7 @@ module Jekyll
           image_dest_path = image_src
           image_dest_url = image_src
           natural_width, natural_height = FastImage.size(image_dest_url)
-          # width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
+          width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
           fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/#{type}/#{transformations_string}w_#{preset["fallback_max_width"]}/#{image_dest_url}"
         else
           # It’s a local image
@@ -235,7 +235,7 @@ module Jekyll
           end
           if File.exist?(image_src_path)
             natural_width, natural_height = FastImage.size(image_src_path)
-            # width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
+            width_height = "width=\"#{natural_width}\" height=\"#{natural_height}\""
             fallback_url = "https://res.cloudinary.com/#{settings["cloud_name"]}/image/#{type}/#{transformations_string}w_#{preset["fallback_max_width"]}/#{image_dest_url}"
           else
             natural_width = 100_000


### PR DESCRIPTION
This pull requests adds a vry small but useful update - a `url`
setting that overrides the `site.url` setting.

This is useful for two use cases:

1. When your images are stored on different server than where your site is hosted, use the `url` setting to point correctly to them.

2. In development mode, `site.url` is overridden by Jekyll to `localhost:4000`. This has the unfortunate consequence of breaking all
Cloudinary tagged images on your site, because Cloudinary cannot fetch remotely from your localhost. Jekyll recommends that you run the site in `production` mode as a work around, but this has the consequence of pointing all internal links to your site's domain.

Using the `url` setting you can mitigate this by pointing the loudinary images to the url where they exist, while allowing your development site to still function correctly.