### PR TITLE
Allow Jekyll v4

### DIFF
--- a/jekyll-cloudinary.gemspec
+++ b/jekyll-cloudinary.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   DESC
 
   spec.add_runtime_dependency "fastimage", "~> 2.0"
-  spec.add_runtime_dependency "jekyll", "~> 3.6"
+  spec.add_runtime_dependency "jekyll", ">= 3.6", "< 5"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Avoid dependency issue when using Jekyll 4.