### PR TITLE
Updated docs: handling liquid variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ You should obviously not add to preset attributes that should have different val
 
 You can set a `class`, `aria-*` attributes for enhanced accessibility, or even `data-*` attributes you would like to use later with CSS or JavaScript.
 
+Also it's possible to pass liquid variables inside the tags, so for example if you have your picture path in the front matter (in the post markdown file), you can send it to Cloudinary Plugin, such as:
+``` 
+{% cloudinary {{page.thumbnail}} class="post-image" itemprop="image" alt="{{page.title}} image"%}
+```
+
+
 ## Liquid tag attributes
 
 You can add attributes to the liquid tag, after the image path:


### PR DESCRIPTION
I turned crazy trying to find this feature, but looking in the code a few days ago I found that in the plugin constructor it's able to parse {{ }} variables. I added to the docs.